### PR TITLE
Fixed pointer check to compile with GCC 11

### DIFF
--- a/agent/HwParse.cc
+++ b/agent/HwParse.cc
@@ -1543,7 +1543,7 @@ HwProbe::hd2value (hd_t *hd)
 
     // map of resources
 
-    if (hd->res > 0)
+    if (hd->res)
     {
 	YCPMap map;
 	hd_res_t *resource;

--- a/package/yast2-hardware-detection.changes
+++ b/package/yast2-hardware-detection.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar  1 16:47:31 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed pointer check to compile with GCC 11 (bsc#1181916)
+- 4.1.2
+
+-------------------------------------------------------------------
 Tue Aug 27 11:10:25 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - add bug number (bsc#1148310)

--- a/package/yast2-hardware-detection.spec
+++ b/package/yast2-hardware-detection.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-hardware-detection
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1181916

## Problem

GCC 11 (correctly) complained that a pointer was checked if it's `> 0`.


## Fix

Do the correct check: If the pointer is non-null.

`hd` has type `hd_t`:

https://github.com/openSUSE/hwinfo/blob/master/src/hd/hd.h#L2201-L2603

which has a pointer `res` of type `hd_res_t`:

https://github.com/openSUSE/hwinfo/blob/master/src/hd/hd.h#L2432

https://github.com/openSUSE/hwinfo/blob/master/src/hd/hd.h#L1827-L1847